### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,9 +4,10 @@ title: RoboCupシミュレーション日本コミュニティ
 ---
 
 ## 今後のイベント
-- 2024年11月30日〜12月1日 [秋キャンプ2024](events/2024/camp){:target="_blank"}
+- 2025年5月2日〜5月5日 [JapanOpen2025](events/2025/JapanOpen){:target="_blank"}
 
 ### 開催済み
+- 2024年11月30日〜12月1日 [秋キャンプ2024](events/2024/camp){:target="_blank"}
 - 2024年4月27-29日 [JapanOpen2024](events/2024/japanopen){:target="_blank"}
 - 2023年11月4日〜5日 [秋キャンプ2023](events/2023/camp){:target="_blank"}
 - 2023年5月4-7日 [JapanOpen2023](events/2023/japanopen){:target="_blank"}


### PR DESCRIPTION
JapanOpen2025の情報を「今後のイベント」に追加し，秋キャンプ2024の情報を「開催済み」に移動